### PR TITLE
I've just added an additional gettext call to allow users to override default plugin translations

### DIFF
--- a/trunk/woocommerce-pdf-italian-add-on.php
+++ b/trunk/woocommerce-pdf-italian-add-on.php
@@ -15,7 +15,10 @@
 //Thanks to Nicola Mustone https://gist.github.com/SiR-DanieL
 
 function wcpdf_IT_load_plugin_textdomain() {
-	load_plugin_textdomain( 'woocommerce-pdf-italian-add-on', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+	$domain = 'woocommerce-pdf-italian-add-on';
+	$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
+	load_textdomain( $domain, WP_LANG_DIR."/plugins/{$domain}-{$locale}.mo" );
+	load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
 }
 add_action( 'plugins_loaded', 'wcpdf_IT_load_plugin_textdomain' );
 


### PR DESCRIPTION
I've just added an additional gettext call to allow users to override default plugin translations (inspired by http://geertdedeckere.be/article/loading-wordpress-language-files-the-right-way)
It's a largely used translation override trick, please add it to your plugin so plugin users can easily override its default translations.

Here is an example of my wp-content/languages/plugins folder:
![pull request](https://cloud.githubusercontent.com/assets/675348/6221794/eb3b2344-b648-11e4-9c4e-a1f9e5002f2d.png)

P.S. parlo anche in italiano