### PR TITLE
fix broken path to receipt file

### DIFF
--- a/trunk/includes/class-wcpdf-integration.php
+++ b/trunk/includes/class-wcpdf-integration.php
@@ -88,7 +88,7 @@ class wcpdf_Integration_Italian_add_on extends WooCommerce_Italian_add_on {
 	}
 	
 	public function wcpdf_template_files( $template, $template_type ) {
-		global $wpo_wcpdf;
+		global $wcpdf_IT;
 	
 		// bail out if file already exists in default or custom path!
 		if ( file_exists( $template ) ) {
@@ -96,7 +96,7 @@ class wcpdf_Integration_Italian_add_on extends WooCommerce_Italian_add_on {
 		}
 		
 		if ( $template_type == 'receipt') {
-			$receipt_template = dirname(__FILE__) . '/templates/pdf/Simple/receipt.php';
+			$receipt_template = $wcpdf_IT->plugin_path . 'templates/pdf/Simple/receipt.php';
 			if( file_exists( $receipt_template ) ) {
 				$template = $receipt_template;
 			}

--- a/trunk/includes/class-wcpdf-integration.php
+++ b/trunk/includes/class-wcpdf-integration.php
@@ -118,4 +118,3 @@ class wcpdf_Integration_Italian_add_on extends WooCommerce_Italian_add_on {
 }
 $wcpdf_it_add_on = new wcpdf_Integration_Italian_add_on();
 endif;
-?>


### PR DESCRIPTION
compatibility class was moved to includes folder, but template path was not adjusted accordingly. Naturally, this also needs to be pushed to the new tags folder.
