### PR TITLE
Add new billing fields to WooCommerce Address

### DIFF
--- a/woocommerce-pdf-italian-add-on.php
+++ b/woocommerce-pdf-italian-add-on.php
@@ -97,6 +97,8 @@ class WooCommerce_Italian_add_on {
 			add_filter( 'woocommerce_customer_meta_fields', array( $this, 'customer_meta_fields') );
 			add_filter( 'manage_edit-shop_order_columns', array( $this, 'add_invoice_type_column' ));
 			add_action( 'manage_shop_order_posts_custom_column', array( $this, 'invoice_type_column_data' ));
+			/* === Add new foleds to Billing Address === */
+			add_filter( 'woocommerce_get_order_address', array( $this, 'add_fields_to_order_address' ), 10, 3 );
 
 		} else {
 			add_action( 'admin_notices', array ( $this, 'check_wc' ) );
@@ -517,6 +519,32 @@ table.wp-list-table .column-invoice_type{width:48px; text-align:center; color:#9
 		}
 		return $column;
 	}
+
+	/**
+	 * Filter get address method for WC_Order
+	 *
+	 * @author Andrea Grillo <info@andreagrillo.it>
+	 * @param array $address
+	 * @param string $type
+	 * @param \WC_Order $order
+	 * @return array
+	 */
+	public function add_fields_to_order_address( $address, $type, $order ){
+		if( 'billing' == $type ){
+			$custom_fields = array(
+                '_billing_invoice_type',
+                '_billing_cf'
+            );
+
+			foreach( $custom_fields as $key ) {
+				$value  = $order->get_meta( $key );
+				$key    = str_replace( '_' .$type . '_', '', $key );
+				$value && $address[ $key ] = $value;
+			}
+		}
+
+		return $address;
+    }
 }
 endif;
 


### PR DESCRIPTION
Salve Ragazzi, 

sono Andrea e scrivo per conto di [YITH](https://yithemes.com). 
Ho aggiunto alla classe principale del plugin un metodo che permette di filtrare il get_address di WooCommerce. In questo modo i campi che voi aggiungete sono disponibili a tutti i plugin di terze parti che utilizzano il billing address di WooCommerce. 
Il problema mi è stato segnalato da un cliente che utilizza il nostro [YITH WooCommerce Multi Vendor](https://yithemes.com/themes/plugins/yith-woocommerce-multi-vendor/) ed il vostro plugin. In breve, i dati di fatturazione aggiunti da voi  non vengono inseriti nei sotto ordini dei venditori e nelle email. 

Ho passato al mio cliente, come fix temporaneo, questo codice:

`add_filter( 'woocommerce_get_order_address', 'yith_filter_get_order_address', 10, 3 );

if( ! function_exists( 'yith_filter_get_order_address' ) ) {
	/**
	 * Filter get address method for WC_Order
	 *
	 * @author Andrea Grillo <andrea.grillo@yithemes.com>
	 * @param array $address
	 * @param string $type
	 * @param \WC_Order $order
	 * @return array
	 */
	function yith_filter_get_order_address( $address, $type, $order ) {
	    if( class_exists( 'WooCommerce_Italian_add_on' ) && 'billing' == $type ){
		    $custom_fields = array( '_billing_invoice_type', '_billing_cf' );

		    foreach( $custom_fields as $key ) {
			    $value  = $order->get_meta( $key );
			    $key    = str_replace( '_' .$type . '_', '', $key );
			    $value && $address[ $key ] = $value;
		    }
        }

		return $address;
	}
}`

Che poi ho deciso di committare all'interno del vostro plugin. Se avete altri campi da aggiungere potete inserirli all'interno dell'array ` $custom_fields = array( '_billing_invoice_type', '_billing_cf' );` che trovate nel mio codice. 

Spero di aver fatto una cosa gradita, per qualsiasi dubbio scrivetemi pure. 
Grazie.
AG